### PR TITLE
Support retrieval of power consumption data for HS110 smart plugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ await myTPLink.getHS100("My Smart Plug 3").powerOff();
 await myTPLink.getHS100("My Smart Plug 4").powerOff();
 ```
 
+To retrieve power consumption data for the HS110:
+
+```javascript
+await myTPLink.getHS110("My Smart Plug").getPowerUsage();
+```
+
 ### Smartbulbs (LB100/110/120/130)
 
 If you have an LB100/110/120, you can change it's state with:

--- a/hs110.js
+++ b/hs110.js
@@ -1,0 +1,38 @@
+/**
+ * @package     tplink-cloud-api
+ * @author      Alexandre Dumont <adumont@gmail.com>
+ * @copyright   (C) 2017 - Alexandre Dumont
+ * @license     https://www.gnu.org/licenses/gpl-3.0.txt
+ * @link        http://itnerd.space
+ */
+
+/* This file is part of tplink-cloud-api.
+
+tplink-cloud-api is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+tplink-cloud-api is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
+
+var TPLinkDevice = require('./device.js');
+var HS100 = require('./hs100.js');
+
+class HS110 extends HS100 {
+  constructor(tpLink, deviceInfo) {
+    super(tpLink, deviceInfo);
+  }
+
+  async getPowerUsage() {
+    let r = await super.tplink_request({"emeter": {"get_realtime": null}})
+    return JSON.parse(JSON.parse(r).result.responseData).emeter.get_realtime
+  }
+}
+
+module.exports = HS110;
+

--- a/tplink.js
+++ b/tplink.js
@@ -23,6 +23,7 @@ tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
 var rp = require('request-promise');
 var uuidV4 = require('uuid/v4');
 var HS100 = require("./hs100.js")
+var HS110 = require("./hs110.js")
 var LB100 = require("./lb100.js")
 var LB130 = require("./lb130.js")
 var _ = require('lodash');
@@ -108,6 +109,10 @@ class TPLink {
   // for an HS100 or HS110 smartplug
   getHS100(alias) {
     return new HS100(this, _.find(this.deviceList, { "alias": alias }));
+  }
+
+  getHS110(alias) {
+    return new HS110(this, _.find(this.deviceList, { "alias": alias }));
   }
 
   // for an LB100, LB110 & LB120


### PR DESCRIPTION
Allows retrieval of power consumption data from HS110 smart plugs, which returns something similar to:

```
{ current: 0.01685,
  voltage: 242.919295,
  power: 0,
  total: 0.546,
  err_code: 0 }
```