### PR TITLE
Reduce node modules size

### DIFF
--- a/device.js
+++ b/device.js
@@ -20,7 +20,7 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
 
-var rp = require('request-promise');
+var axios = require('axios')
 
 class TPLinkDevice {
   constructor(tpLink, deviceInfo){
@@ -46,22 +46,22 @@ class TPLinkDevice {
       "method":"passthrough",
       "params": {
         "deviceId": this.device.deviceId,
-        "requestData": JSON.stringify( command )
+        "requestData": JSON.stringify(command)
       }
     }
 
     let request = { method: 'POST',
       url: this.device.appServerUrl,
-      qs: this.params,
-      headers:
-       { 'cache-control': 'no-cache',
-         'content-type': 'application/json' },
-      body: JSON.stringify( payload )
+      params: this.params,
+      headers: {
+        'cache-control': 'no-cache'
+      },
+      data: payload
     }
 
-    return await rp( request );
+    let response = await axios(request)
+    return JSON.stringify(response.data);
   }
-
 }
 
 module.exports = TPLinkDevice;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "LB130"
   ],
   "dependencies": {
-    "request": "^2.81.0",
-    "request-promise": "^4.2.1",
+    "axios": "^0.17.1",
     "lodash.find": "^4.6.0",
     "uuid": "^3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
+    "lodash.find": "^4.6.0",
     "uuid": "^3.1.0"
   }
 }

--- a/tplink.js
+++ b/tplink.js
@@ -20,7 +20,7 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
 
-var rp = require('request-promise');
+var axios = require('axios');
 var uuidV4 = require('uuid/v4');
 var HS100 = require("./hs100.js")
 var HS110 = require("./hs110.js")
@@ -45,7 +45,7 @@ class TPLink {
       locale: 'es_ES'
     };
 
-    const login_payload = JSON.stringify({
+    const login_payload = {
       "method": "login", "url": "https://wap.tplinkcloud.com",
       "params": {
         "appType": "Kasa_Android",
@@ -53,23 +53,21 @@ class TPLink {
         "cloudUserName": user,
         "terminalUUID": termid
       }
-    }
-    );
+    };
 
     const request = {
       method: 'POST',
-      uri: "https://wap.tplinkcloud.com",
-      qs: params,
-      body: login_payload,
+      url: 'https://wap.tplinkcloud.com',
+      params: params,
+      data: login_payload,
       headers: {
         'Connection': 'Keep-Alive',
-        'Content-Type': 'application/json',
         'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; A0001 Build/M4B30X)'
-      },
+      }
     };
 
-    const response = await rp(request);
-    const token = JSON.parse(response).result.token;
+    const response = await axios(request);
+    const token = response.data.result.token;
     return new TPLink(token, termid);
   }
 
@@ -91,16 +89,13 @@ class TPLink {
 
     const request = {
       method: 'POST',
-      uri: 'https://wap.tplinkcloud.com',
-      qs: { token: this.token },
-      body: JSON.stringify({ method: "getDeviceList" }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      url: 'https://wap.tplinkcloud.com',
+      params: { token: this.token },
+      data: { method: "getDeviceList" }
     };
 
-    const response = await rp(request)
-    const deviceList = JSON.parse(response).result.deviceList
+    const response = await axios(request)
+    const deviceList = response.data.result.deviceList
     this.deviceList = deviceList
 
     return deviceList

--- a/tplink.js
+++ b/tplink.js
@@ -26,7 +26,7 @@ var HS100 = require("./hs100.js")
 var HS110 = require("./hs110.js")
 var LB100 = require("./lb100.js")
 var LB130 = require("./lb130.js")
-var _ = require('lodash');
+var find = require("lodash.find");
 
 class TPLink {
   constructor(token, termid) {
@@ -108,21 +108,21 @@ class TPLink {
 
   // for an HS100 or HS110 smartplug
   getHS100(alias) {
-    return new HS100(this, _.find(this.deviceList, { "alias": alias }));
+    return new HS100(this, find(this.deviceList, { "alias": alias }));
   }
 
   getHS110(alias) {
-    return new HS110(this, _.find(this.deviceList, { "alias": alias }));
+    return new HS110(this, find(this.deviceList, { "alias": alias }));
   }
 
   // for an LB100, LB110 & LB120
   getLB100(alias) {
-    return new LB100(this, _.find(this.deviceList, { "alias": alias }));
+    return new LB100(this, find(this.deviceList, { "alias": alias }));
   }
 
   // for an LB130 lightbulb
   getLB130(alias) {
-    return new LB130(this, _.find(this.deviceList, { "alias": alias }));
+    return new LB130(this, find(this.deviceList, { "alias": alias }));
   }
 
 }


### PR DESCRIPTION
I'm using your library for a [node-red](https://nodered.org/) node.
Since many people still use old node-js versions I use babel to transpile your code to es6.

While packaging I noticed that I packaged lot of big dependencies. `request` also has dependencies on `tls`, `fs`, `net` which decreases the portability.

You currently use `request` and `lodash`, both are very big libraries.

Thats what I did:
- Swapped out `request` with `axios` while maintaining the api of `device.tplink_request`.
Axios is more portable and has native promise support, also saves about 5MB dependencies.
- used only `lodash.find` instead of the whole set of `lodash` modules, which saves another 5MB

The dependencies shrunk from 11MB to 0,73MB:
![test](https://user-images.githubusercontent.com/7721625/33240482-b1db59b0-d2b6-11e7-8aed-d379f552bcd1.gif)

As I'm only in possession of a few HS100 I only tested the functionality for this device. Due to the nature of the changes my confidence is very high that the test with the HS100 suffices.

My module shrunk by a factor of 10:
### before
<img width="406" alt="bildschirmfoto 2017-11-26 um 14 39 38" src="https://user-images.githubusercontent.com/7721625/33240551-d5d86a5a-d2b7-11e7-9ebd-673341d71310.png">

### after
<img width="397" alt="bildschirmfoto 2017-11-26 um 14 40 06" src="https://user-images.githubusercontent.com/7721625/33240552-d9f220ae-d2b7-11e7-8fd4-88a2a5ed500c.png">