### PR TITLE
Remove connection header for browser

### DIFF
--- a/lib/tplink.js
+++ b/lib/tplink.js
@@ -63,7 +63,6 @@ class TPLink {
       params: params,
       data: login_payload,
       headers: {
-        'Connection': 'Keep-Alive',
         'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; A0001 Build/M4B30X)'
       }
     };


### PR DESCRIPTION
When using this package with webpack, the browser-compiled code runs fine except for the Connection:keep-alive. This is because Connection is a forbidden header.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive