### PR TITLE
feat(device): add connected and disconnected getters

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015", "stage-0"],
-  "plugins": ["syntax-async-functions", "transform-regenerator"]
-}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ async function main() {
   // alternatively, map to light or plug objects that can directly be invoked (eg: .transitionLightState(...))
   for (const d of rawDevices) {
     const device = tplink.newDevice(d);
+
+    if (device.disconnected) {
+      // aka !connected
+      continue; // can't operate on a device that's not connected to the internet
+    }
+
     console.log(
       device.type,
       "(",

--- a/lib/device.spec.ts
+++ b/lib/device.spec.ts
@@ -30,7 +30,14 @@ describe("tplink device", () => {
     expect(d.id).to.equal("1992");
     expect(d.alias).to.equal("bedroom tv plug2");
     expect(d.humanName).to.equal("bedroom tv plug2");
-    expect(d.status).to.equal(1);
     expect(d.name).to.equal("name");
+    expect(d.status).to.equal(1);
+    expect(d.connected).to.be.true;
+    expect(d.disconnected).to.be.false;
+
+    d.device.status = 0;
+    expect(d.connected).to.be.false;
+    expect(d.disconnected).to.be.true;
+    expect(d.status).to.equal(0);
   });
 });

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -82,6 +82,12 @@ export default class TPLinkDevice {
   get name() {
     return this.device.deviceName;
   }
+  get disconnected() {
+    return this.status !== 1;
+  }
+  get connected() {
+    return this.status === 1;
+  }
   get status() {
     return this.device.status;
   }


### PR DESCRIPTION
This is an alias for checking a status, but it is
needed because the api will return an error upon
attempting to toggle the state of a disconnected device.

fixes #9