### PR TITLE
feat(api/errors): better response error type for introspection

### DIFF
--- a/lib/api-utils.spec.ts
+++ b/lib/api-utils.spec.ts
@@ -1,14 +1,51 @@
 import { expect } from "chai";
 import "mocha";
-import { checkError } from "./api-utils";
+import { checkError, ResponseError } from "./api-utils";
+import { AxiosResponse } from "axios";
+
+function mockAxiosResponse(
+  code: number = 0,
+  status: number = 200
+): AxiosResponse<any> {
+  return {
+    status,
+    data: { error_code: code },
+    statusText: "OK",
+    headers: {},
+    config: {}
+  };
+}
+
 describe("api-utils module", () => {
   describe("checkError()", () => {
     it("should detect errors", () => {
       expect(checkError).to.exist;
-      expect(() => checkError({})).to.not.throw();
-      expect(() => checkError({ data: { error_code: 0 } })).to.not.throw(Error);
-      expect(() => checkError({ data: { error_code: 10 } })).to.throw(Error);
-      expect(() => checkError({ data: { error_code: -1 } })).to.throw(Error);
+      expect(() => checkError(null)).to.throw(Error);
+      expect(() =>
+        checkError({
+          data: {},
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {}
+        })
+      ).to.throw(ResponseError);
+      expect(() => checkError(mockAxiosResponse())).to.not.throw(ResponseError);
+      expect(() => checkError(mockAxiosResponse(10))).to.throw(ResponseError);
+      expect(() => checkError(mockAxiosResponse(-1))).to.throw(ResponseError);
+      expect(() => checkError(mockAxiosResponse(-1, 400))).to.throw(
+        ResponseError
+      );
+    });
+  });
+  describe("ResponseError", () => {
+    describe("should allow error introspection for", () => {
+      it("token expiration", () => {
+        let e = new ResponseError(mockAxiosResponse());
+        expect(e.isTokenExpired()).to.be.false;
+        e = new ResponseError(mockAxiosResponse(-20651));
+        expect(e.isTokenExpired()).to.be.true;
+      });
     });
   });
 });

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -1,7 +1,29 @@
-export function checkError(response) {
-  if (response && response.data && response.data.error_code !== 0) {
-    throw new Error(
-      `response error: ${response.data.msg || response.data.error_code}`
+import { AxiosResponse } from "axios";
+
+export function checkError(response: AxiosResponse<any>): void {
+  if (!response || !response.data) {
+    throw new Error("response error: invalid or empty object received");
+  } else if (response.data.error_code !== 0) {
+    throw new ResponseError(response);
+  }
+}
+
+export class ResponseError extends Error {
+  errorCode: number;
+  response: AxiosResponse<any>;
+  constructor(response: AxiosResponse<any>) {
+    super(
+      `response error: code=${response.data.error_code}, status="${
+        response.statusText
+      }", message=${JSON.stringify(response.data.msg || response.data)}`
     );
+    this.errorCode = +response.data.error_code;
+    this.response = response;
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, ResponseError.prototype);
+  }
+  isTokenExpired(): boolean {
+    return this.errorCode === -20651;
   }
 }

--- a/lib/tplink.spec.ts
+++ b/lib/tplink.spec.ts
@@ -14,7 +14,12 @@ describe("tplink", () => {
         .onPost("https://wap.tplinkcloud.com")
         .replyOnce(200, {
           error_code: 0,
-          result: { token: "feedbeef1234" }
+          result: {
+            token: "feedbeef1234",
+            regTime: "2017-12-09 03:53:19",
+            accountId: "12456",
+            email: "someone@somewhere.com"
+          }
         })
         // device list
         .onAny("https://wap.tplinkcloud.com")

--- a/lib/tplink.ts
+++ b/lib/tplink.ts
@@ -29,7 +29,27 @@ import hs110 from "./hs110";
 import lb100 from "./lb100";
 import lb130 from "./lb130";
 
-export async function login(user, passwd, termid = v4()): Promise<TPLink> {
+/* Example
+{
+  accountId: '12456',
+  regTime: '2017-12-09 03:53:19',
+  email: 'your-email@some-domain.com',
+  token: 'feed-beef...'
+} 
+*/
+interface LoginResponse {
+  accountId: string;
+  regTime: string;
+  email: string;
+  token: string;
+  // there is no refresh token in response
+}
+
+export async function login(
+  user: string,
+  passwd: string,
+  termid: string = v4()
+): Promise<TPLink> {
   if (!user) {
     throw new Error("missing required user parameter");
   } else if (!passwd) {
@@ -72,7 +92,7 @@ export default class TPLink {
   token: string;
   termid: string;
   deviceList: any[];
-  constructor(token, termid) {
+  constructor(token: string, termid: string = v4()) {
     this.token = token;
     this.termid = termid;
   }


### PR DESCRIPTION
Will allow type checking `ResponseError` to discern concrete errors
like those seen in #15.