### PR TITLE
HS200 (Smart switches) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Introduction
 
-The `tplink-cloud-api` NPM module allows your to remotely control your TP-Link smartplugs (HS100, HS110) and smartbulbs (LB100, LB110, LB120, LB130) using the TP-Link cloud web service, from anywhere, without the need to be on the same wifi/lan.
+The `tplink-cloud-api` NPM module allows your to remotely control your TP-Link smartplugs (HS100, HS110), smart switches (HS200), and smartbulbs (LB100, LB110, LB120, LB130) using the TP-Link cloud web service, from anywhere, without the need to be on the same wifi/lan.
 
 It's especially useful in scenarios where you want to control your devices from public web services, like IFTTT, Thinger.io, Webtasks.io, Glitch.com...
 
@@ -71,6 +71,10 @@ To retrieve power consumption data for the HS110:
 ```javascript
 await tplink.getHS110("My Smart Plug").getPowerUsage();
 ```
+
+### Smart Switches (HS200)
+
+You can  toggle smart switches with the same API as the smart plugs.
 
 ### Smartbulbs (LB100/110/120/130)
 

--- a/lib/hs200.spec.ts
+++ b/lib/hs200.spec.ts
@@ -1,0 +1,95 @@
+import axios from "axios";
+import axiosMockAdapter from "axios-mock-adapter";
+import { expect } from "chai";
+import "mocha";
+import hs200 from "./hs200";
+import tplink from "./tplink";
+
+describe("hs200", () => {
+  const lTplink = new tplink("token", "termid");
+  describe("can toggle plug state", () => {
+    it("reads correctly", async () => {
+      const mock = new axiosMockAdapter(axios);
+      // off
+      mock
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 0}}}'
+          }
+        })
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 0}}}'
+          }
+        })
+        // turn on
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 1}}}'
+          }
+        })
+        // on
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 1}}}'
+          }
+        })
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 1}}}'
+          }
+        })
+        // power off
+        .onPost("/mock-server")
+        .replyOnce(200, {
+          error_code: 0,
+          result: {
+            responseData: '{"system":{"get_sysinfo":{"relay_state": 0}}}'
+          }
+        })
+        .onAny("/mock-server")
+        .reply(400, { error_code: 2, msg: "bad request" });
+
+      const d = new hs200(lTplink, {
+        appServerUrl: "/mock-server",
+        fwVer: "1.2.5",
+        alias: "light switch",
+        status: 1,
+        deviceId: "19921",
+        role: "role12",
+        deviceMac: "feedbeefd",
+        deviceName: "name",
+        deviceType: "IOT.SMARTPLUGSWITCH",
+        deviceModel: "model"
+      });
+
+      expect(d.genericType).to.equal("switch");
+
+      let isOn = await d.isOn();
+      expect(isOn).to.be.false;
+
+      let isOff = await d.isOff();
+      expect(isOff).to.be.true;
+
+      await d.powerOn();
+
+      isOn = await d.isOn();
+      expect(isOn).to.be.true;
+
+      isOff = await d.isOff();
+      expect(isOff).to.be.false;
+
+      await d.powerOff();
+    });
+  });
+});

--- a/lib/hs200.ts
+++ b/lib/hs200.ts
@@ -1,0 +1,30 @@
+/**
+ * @package     tplink-cloud-api
+ * @author      Alexandre Dumont <adumont@gmail.com>
+ * @copyright   (C) 2017 - Alexandre Dumont
+ * @license     https://www.gnu.org/licenses/gpl-3.0.txt
+ * @link        http://itnerd.space
+ */
+
+/* This file is part of tplink-cloud-api.
+
+tplink-cloud-api is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+tplink-cloud-api is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
+
+import HS100 from "./HS100";
+
+export default class HS200 extends HS100 {
+ constructor(tpLink, deviceInfo) {
+   super(tpLink, deviceInfo);
+   this.genericType = "switch";
+ }
+}

--- a/lib/hs200.ts
+++ b/lib/hs200.ts
@@ -20,9 +20,9 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
 
-import HS100 from "./hs100";
+import hs100 from "./hs100";
 
-export default class HS200 extends HS100 {
+export default class HS200 extends hs100 {
  constructor(tpLink, deviceInfo) {
    super(tpLink, deviceInfo);
    this.genericType = "switch";

--- a/lib/hs200.ts
+++ b/lib/hs200.ts
@@ -20,7 +20,7 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 tplink-cloud-api. If not, see http://www.gnu.org/licenses/. */
 
-import HS100 from "./HS100";
+import HS100 from "./hs100";
 
 export default class HS200 extends HS100 {
  constructor(tpLink, deviceInfo) {

--- a/lib/tplink.ts
+++ b/lib/tplink.ts
@@ -26,6 +26,7 @@ import { checkError } from "./api-utils";
 import device from "./device";
 import hs100 from "./hs100";
 import hs110 from "./hs110";
+import hs200 from "./hs200";
 import lb100 from "./lb100";
 import lb130 from "./lb130";
 
@@ -35,7 +36,7 @@ import lb130 from "./lb130";
   regTime: '2017-12-09 03:53:19',
   email: 'your-email@some-domain.com',
   token: 'feed-beef...'
-} 
+}
 */
 interface LoginResponse {
   accountId: string;
@@ -162,6 +163,12 @@ export default class TPLink {
       }
       return new hs100(this, deviceInfo);
     }
+
+    if (type.includes("switch")) {
+      if (model && model.includes("200")) {
+        return new hs200(this, deviceInfo);
+      }
+    }
     return new device(this, deviceInfo);
   }
 
@@ -184,6 +191,11 @@ export default class TPLink {
   // for an HS110 smartplug
   getHS110(alias) {
     return new hs110(this, this.findDevice(alias));
+  }
+
+  // for an HS200 smart switch
+  getHS200(alias) {
+    return new hs200(this, this.findDevice(alias));
   }
 
   // for an LB100, LB110 & LB120


### PR DESCRIPTION
 - Product link: https://www.tp-link.com/us/products/details/cat-5622_HS200.html
 - API is similar to HS100, since they're just toggled.